### PR TITLE
Generacion de PDF

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,11 +5,15 @@ WORKDIR /app
 ENV PYTHONPATH=/app
 RUN mkdir -p /workspace/backend
 
-# Instalar dependencias del sistema
+# Instalar dependencias del sistema 
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     libpq-dev \
+    #lib dependencias para pdf
+    libjpeg-dev \
+    libpng-dev \
+    libfreetype6-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copiar requirements

--- a/backend/api/app/db/repositories/prediccion_repository.py
+++ b/backend/api/app/db/repositories/prediccion_repository.py
@@ -94,3 +94,18 @@ class PrediccionRepository:
 
         result = await self._session.execute(query)
         return list(result.scalars().all())
+
+    async def get_by_id(self, prediccion_id: Union[str, UUID]) -> Optional[Prediccion]:
+        """Obtiene una predicción por su ID.
+
+        Args:
+            prediccion_id: Identificador de la predicción
+
+        Returns:
+            La entidad `Prediccion` si existe, de lo contrario `None`.
+        """
+        query = sa.select(Prediccion).where(
+            Prediccion.id == coerce_uuid(prediccion_id, field="id")
+        )
+        result = await self._session.execute(query)
+        return result.scalars().first()

--- a/backend/api/app/dto/siembra.py
+++ b/backend/api/app/dto/siembra.py
@@ -20,6 +20,8 @@ class RecomendacionResponse(BaseModel):
     costos_estimados: Dict[str, float] = Field(default_factory=dict)
     fecha_generacion: datetime
     datos_entrada: Dict[str, Any] = Field(default_factory=dict)
+    # Se agregó este campo para que el front reciba el ID guardado y pueda solicitar ese PDF puntual.
+    prediccion_id: Optional[str] = Field(default=None, description="ID de la predicción guardada")
 
 
 class RecomendacionPrincipalSiembra(BaseModel):

--- a/backend/api/app/services/pdf_generator.py
+++ b/backend/api/app/services/pdf_generator.py
@@ -1,0 +1,337 @@
+"""Servicio para generar PDFs de recomendaciones de siembra."""
+from __future__ import annotations
+
+from io import BytesIO
+from datetime import datetime, date
+from typing import Any, Dict, List, Optional
+
+from reportlab.lib.pagesizes import letter, A4
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_RIGHT, TA_JUSTIFY
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+    PageBreak,
+    Image,
+)
+from reportlab.lib import colors
+from reportlab.pdfgen import canvas
+
+from ..core.logging import get_logger
+from ..dto.siembra import SiembraRecommendationResponse
+
+
+logger = get_logger("pdf_generator")
+
+
+class PDFGeneratorService:
+    """Servicio para generar PDFs profesionales de recomendaciones de siembra."""
+
+    def __init__(self):
+        """Inicializa el servicio de generación de PDFs."""
+        self.page_width, self.page_height = A4
+        self.margin = 0.5 * inch
+
+    def generate_recommendation_pdf(
+        self,
+        recommendation: SiembraRecommendationResponse,
+        lote_info: Dict[str, Any],
+    ) -> bytes:
+        """Genera un PDF con la recomendación de siembra completa.
+
+        Args:
+            recommendation: Respuesta de recomendación de siembra
+            lote_info: Información adicional del lote
+
+        Returns:
+            Bytes del PDF generado
+        """
+        buffer = BytesIO()
+
+        try:
+            # Crear documento
+            doc = SimpleDocTemplate(
+                buffer,
+                pagesize=A4,
+                rightMargin=self.margin,
+                leftMargin=self.margin,
+                topMargin=self.margin,
+                bottomMargin=self.margin,
+            )
+
+            # Construir elementos del documento
+            story = self._build_pdf_story(recommendation, lote_info)
+
+            # Generar PDF
+            doc.build(story)
+
+            pdf_data = buffer.getvalue()
+            logger.info(
+                "PDF generado exitosamente",
+                extra={
+                    "lote_id": recommendation.lote_id,
+                    "cultivo": recommendation.cultivo,
+                    "pdf_size_kb": len(pdf_data) / 1024,
+                },
+            )
+
+            return pdf_data
+
+        except Exception as exc:
+            logger.exception(
+                "Error al generar PDF de recomendación",
+                extra={"lote_id": recommendation.lote_id},
+            )
+            raise
+
+    def _build_pdf_story(
+        self,
+        recommendation: SiembraRecommendationResponse,
+        lote_info: Dict[str, Any],
+    ) -> List[Any]:
+        """Construye los elementos del documento PDF.
+
+        Args:
+            recommendation: Recomendación de siembra
+            lote_info: Información del lote
+
+        Returns:
+            Lista de elementos Platypus para el documento
+        """
+        styles = getSampleStyleSheet()
+        story: List[Any] = []
+
+        # Crear estilos personalizados
+        title_style = ParagraphStyle(
+            "CustomTitle",
+            parent=styles["Heading1"],
+            fontSize=24,
+            textColor=colors.HexColor("#1a472a"),
+            spaceAfter=10,
+            alignment=TA_CENTER,
+            fontName="Helvetica-Bold",
+        )
+
+        heading_style = ParagraphStyle(
+            "CustomHeading",
+            parent=styles["Heading2"],
+            fontSize=14,
+            textColor=colors.HexColor("#2d5a3d"),
+            spaceAfter=8,
+            spaceBefore=10,
+            fontName="Helvetica-Bold",
+        )
+
+        normal_style = ParagraphStyle(
+            "CustomNormal",
+            parent=styles["Normal"],
+            fontSize=10,
+            alignment=TA_JUSTIFY,
+            spaceAfter=6,
+        )
+
+        # Encabezado
+        story.append(Paragraph("RECOMENDACIÓN DE SIEMBRA", title_style))
+        story.append(Spacer(1, 0.3 * inch))
+
+        # Información general
+        story.append(Paragraph("INFORMACIÓN GENERAL", heading_style))
+        general_data = [
+            ["Cultivo:", recommendation.cultivo.upper()],
+            ["Lote:", lote_info.get("nombre", recommendation.lote_id)],
+            ["Campaña:", lote_info.get("campana", "—")],
+            [
+                "Fecha de consulta:",
+                self._format_datetime(recommendation.fecha_generacion),
+            ],
+            [
+                "Tipo de recomendación:",
+                recommendation.tipo_recomendacion.upper(),
+            ],
+        ]
+        general_table = Table(general_data, colWidths=[2 * inch, 3 * inch])
+        general_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#e8f5e9")),
+                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
+                    ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                    ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 10),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                    ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                ]
+            )
+        )
+        story.append(general_table)
+        story.append(Spacer(1, 0.2 * inch))
+
+        # Datos de entrada del usuario
+        story.append(Paragraph("DATOS INGRESADOS POR EL USUARIO", heading_style))
+        entrada_data = self._build_input_table(recommendation.datos_entrada)
+        entrada_table = Table(entrada_data, colWidths=[2 * inch, 3 * inch])
+        entrada_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#fff3e0")),
+                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
+                    ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 9),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                    ("GRID", (0, 0), (-1, -1), 1, colors.grey),
+                ]
+            )
+        )
+        story.append(entrada_table)
+        story.append(Spacer(1, 0.2 * inch))
+
+        # Recomendación principal
+        story.append(
+            Paragraph("RECOMENDACIÓN PRINCIPAL", heading_style)
+        )
+        rec_principal = recommendation.recomendacion_principal
+        principal_text = f"""
+        <b>Fecha óptima de siembra:</b> {self._format_date(rec_principal.fecha_optima)}<br/>
+        <b>Ventana recomendada:</b> {self._format_date(rec_principal.ventana[0])} a {self._format_date(rec_principal.ventana[1])}<br/>
+        <b>Nivel de confianza:</b> {rec_principal.confianza * 100:.1f}%<br/>
+        """
+        story.append(Paragraph(principal_text, normal_style))
+
+        # Riesgos identificados
+        if rec_principal.riesgos:
+            story.append(Spacer(1, 0.1 * inch))
+            story.append(Paragraph("RIESGOS IDENTIFICADOS", heading_style))
+            for riesgo in rec_principal.riesgos:
+                story.append(Paragraph(f"• {riesgo}", normal_style))
+
+        story.append(Spacer(1, 0.2 * inch))
+
+        # Alternativas
+        if recommendation.alternativas:
+            story.append(Paragraph("ALTERNATIVAS CONSIDERADAS", heading_style))
+            for i, alt in enumerate(recommendation.alternativas, 1):
+                alt_text = f"""
+                <b>Alternativa {i}:</b><br/>
+                Fecha: {self._format_date(alt.get('fecha', '—'))}<br/>
+                Ventana: {self._format_date(alt.get('ventana', ['—', '—'])[0])} a {self._format_date(alt.get('ventana', ['—', '—'])[1])}<br/>
+                Confianza: {alt.get('confianza', 0) * 100:.1f}%<br/>
+                """
+                story.append(Paragraph(alt_text, normal_style))
+
+                if alt.get("pros"):
+                    story.append(Paragraph("<b>Ventajas:</b>", normal_style))
+                    for pro in alt.get("pros", []):
+                        story.append(Paragraph(f"✓ {pro}", normal_style))
+
+                if alt.get("contras"):
+                    story.append(Paragraph("<b>Desventajas:</b>", normal_style))
+                    for contra in alt.get("contras", []):
+                        story.append(Paragraph(f"✗ {contra}", normal_style))
+
+                story.append(Spacer(1, 0.1 * inch))
+
+        story.append(Spacer(1, 0.3 * inch))
+
+        # Pie de página
+        footer_style = ParagraphStyle(
+            "Footer",
+            parent=styles["Normal"],
+            fontSize=8,
+            textColor=colors.grey,
+            alignment=TA_CENTER,
+        )
+        story.append(Paragraph("___" * 20, footer_style))
+        story.append(
+            Paragraph(
+                f"Documento generado: {self._format_datetime(datetime.now())}<br/>"
+                "Agro ML - Sistema de Recomendaciones Agrícolas",
+                footer_style,
+            )
+        )
+
+        return story
+
+    def _build_input_table(self, datos_entrada: Dict[str, Any]) -> List[List[str]]:
+        """Construye tabla con los datos ingresados por el usuario.
+
+        Args:
+            datos_entrada: Diccionario de datos de entrada
+
+        Returns:
+            Lista de listas para la tabla
+        """
+        table_data = [["Campo", "Valor"]]
+
+        # Mapear campos importantes
+        field_labels = {
+            "lote_id": "ID del Lote",
+            "cultivo": "Cultivo",
+            "campana": "Campaña",
+            "fecha_consulta": "Fecha de Consulta",
+            "cliente_id": "ID del Cliente",
+        }
+
+        for key, label in field_labels.items():
+            value = datos_entrada.get(key)
+            if value:
+                if isinstance(value, datetime):
+                    value = self._format_datetime(value)
+                table_data.append([label, str(value)])
+
+        return table_data
+
+    @staticmethod
+    def _format_date(date_value: Any) -> str:
+        """Formatea una fecha para visualización.
+
+        Args:
+            date_value: Valor de fecha (string, datetime, etc.)
+
+        Returns:
+            Fecha formateada
+        """
+        if isinstance(date_value, date):
+            return date_value.strftime("%d/%m/%Y")
+
+        if isinstance(date_value, datetime):
+            return date_value.strftime("%d/%m/%Y")
+
+        if isinstance(date_value, str):
+            # Intentar parsear diferentes formatos
+            formats = ["%Y-%m-%d", "%d-%m-%Y", "%Y/%m/%d", "%d/%m/%Y"]
+            for fmt in formats:
+                try:
+                    parsed = datetime.strptime(date_value, fmt)
+                    return parsed.strftime("%d/%m/%Y")
+                except ValueError:
+                    continue
+            return date_value
+
+        return "—"
+
+    @staticmethod
+    def _format_datetime(dt_value: Any) -> str:
+        """Formatea un datetime para visualización.
+
+        Args:
+            dt_value: Valor de datetime
+
+        Returns:
+            Datetime formateado
+        """
+        if isinstance(dt_value, datetime):
+            return dt_value.strftime("%d/%m/%Y %H:%M:%S")
+
+        if isinstance(dt_value, str):
+            try:
+                parsed = datetime.fromisoformat(dt_value)
+                return parsed.strftime("%d/%m/%Y %H:%M:%S")
+            except (ValueError, AttributeError):
+                return dt_value
+
+        return "—"

--- a/backend/api/app/services/pdf_generator.py
+++ b/backend/api/app/services/pdf_generator.py
@@ -3,23 +3,14 @@ from __future__ import annotations
 
 from io import BytesIO
 from datetime import datetime, date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from reportlab.lib.pagesizes import letter, A4
+from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
-from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_RIGHT, TA_JUSTIFY
-from reportlab.platypus import (
-    SimpleDocTemplate,
-    Paragraph,
-    Spacer,
-    Table,
-    TableStyle,
-    PageBreak,
-    Image,
-)
+from reportlab.lib.enums import TA_CENTER
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
 from reportlab.lib import colors
-from reportlab.pdfgen import canvas
 
 from ..core.logging import get_logger
 from ..dto.siembra import SiembraRecommendationResponse
@@ -105,135 +96,134 @@ class PDFGeneratorService:
         styles = getSampleStyleSheet()
         story: List[Any] = []
 
-        # Crear estilos personalizados
         title_style = ParagraphStyle(
-            "CustomTitle",
+            "HeroTitle",
             parent=styles["Heading1"],
             fontSize=24,
+            leading=30,
             textColor=colors.HexColor("#1a472a"),
-            spaceAfter=10,
             alignment=TA_CENTER,
+            spaceAfter=20,
             fontName="Helvetica-Bold",
         )
-
-        heading_style = ParagraphStyle(
-            "CustomHeading",
-            parent=styles["Heading2"],
-            fontSize=14,
-            textColor=colors.HexColor("#2d5a3d"),
-            spaceAfter=8,
-            spaceBefore=10,
-            fontName="Helvetica-Bold",
-        )
-
-        normal_style = ParagraphStyle(
-            "CustomNormal",
-            parent=styles["Normal"],
-            fontSize=10,
-            alignment=TA_JUSTIFY,
+        body_style = ParagraphStyle(
+            "BodyLine",
+            parent=styles["BodyText"],
+            fontSize=12,
+            leading=18,
             spaceAfter=6,
         )
+        star_section_style = ParagraphStyle(
+            "StarSection",
+            parent=styles["Heading2"],
+            fontSize=14,
+            leading=20,
+            textColor=colors.HexColor("#1a472a"),
+            spaceAfter=12,
+            fontName="Helvetica-Bold",
+        )
+        block_heading_style = ParagraphStyle(
+            "BlockHeading",
+            parent=styles["Heading3"],
+            fontSize=13,
+            leading=18,
+            textColor=colors.HexColor("#2d5a3d"),
+            spaceBefore=18,
+            spaceAfter=8,
+            fontName="Helvetica-Bold",
+        )
 
-        # Encabezado
         story.append(Paragraph("RECOMENDACIÓN DE SIEMBRA", title_style))
-        story.append(Spacer(1, 0.3 * inch))
 
-        # Información general
-        story.append(Paragraph("INFORMACIÓN GENERAL", heading_style))
-        general_data = [
-            ["Cultivo:", recommendation.cultivo.upper()],
-            ["Lote:", lote_info.get("nombre", recommendation.lote_id)],
-            ["Campaña:", lote_info.get("campana", "—")],
-            [
-                "Fecha de consulta:",
-                self._format_datetime(recommendation.fecha_generacion),
-            ],
-            [
-                "Tipo de recomendación:",
-                recommendation.tipo_recomendacion.upper(),
-            ],
+        campaign = (
+            lote_info.get("campana")
+            or recommendation.datos_entrada.get("campana")
+            or "—"
+        )
+        lote_label = recommendation.lote_id or "—"
+        fecha_generacion = self._format_datetime_for_pdf(
+            recommendation.fecha_generacion
+        )
+        cultivo = recommendation.cultivo.title() if recommendation.cultivo else "—"
+
+        meta_lines = [
+            f"Campaña {campaign}",
+            f"Lote: {lote_label}",
+            f"Fecha de generación: {fecha_generacion}",
+            f"Cultivo {cultivo}",
         ]
-        general_table = Table(general_data, colWidths=[2 * inch, 3 * inch])
-        general_table.setStyle(
-            TableStyle(
-                [
-                    ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#e8f5e9")),
-                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
-                    ("ALIGN", (0, 0), (-1, -1), "LEFT"),
-                    ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
-                    ("FONTSIZE", (0, 0), (-1, -1), 10),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
-                    ("GRID", (0, 0), (-1, -1), 1, colors.grey),
-                ]
-            )
-        )
-        story.append(general_table)
-        story.append(Spacer(1, 0.2 * inch))
+        for line in meta_lines:
+            story.append(Paragraph(line, body_style))
 
-        # Datos de entrada del usuario
-        story.append(Paragraph("DATOS INGRESADOS POR EL USUARIO", heading_style))
-        entrada_data = self._build_input_table(recommendation.datos_entrada)
-        entrada_table = Table(entrada_data, colWidths=[2 * inch, 3 * inch])
-        entrada_table.setStyle(
-            TableStyle(
-                [
-                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#fff3e0")),
-                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
-                    ("ALIGN", (0, 0), (-1, -1), "LEFT"),
-                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-                    ("FONTSIZE", (0, 0), (-1, -1), 9),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
-                    ("GRID", (0, 0), (-1, -1), 1, colors.grey),
-                ]
-            )
-        )
-        story.append(entrada_table)
         story.append(Spacer(1, 0.2 * inch))
+        story.append(Paragraph("⭐ Recomendación Principal", star_section_style))
 
-        # Recomendación principal
-        story.append(
-            Paragraph("RECOMENDACIÓN PRINCIPAL", heading_style)
-        )
         rec_principal = recommendation.recomendacion_principal
-        principal_text = f"""
-        <b>Fecha óptima de siembra:</b> {self._format_date(rec_principal.fecha_optima)}<br/>
-        <b>Ventana recomendada:</b> {self._format_date(rec_principal.ventana[0])} a {self._format_date(rec_principal.ventana[1])}<br/>
-        <b>Nivel de confianza:</b> {rec_principal.confianza * 100:.1f}%<br/>
-        """
-        story.append(Paragraph(principal_text, normal_style))
+        story.append(
+            Paragraph(
+                f"Fecha óptima: {self._format_date(rec_principal.fecha_optima)}",
+                body_style,
+            )
+        )
+        story.append(
+            Paragraph(
+                (
+                    "Ventana recomendada: "
+                    f"{self._format_window(rec_principal.ventana)}"
+                ),
+                body_style,
+            )
+        )
+        story.append(
+            Paragraph(
+                (
+                    "Confianza del modelo: "
+                    f"{rec_principal.confianza * 100:.1f}%"
+                ),
+                body_style,
+            )
+        )
 
-        # Riesgos identificados
-        if rec_principal.riesgos:
-            story.append(Spacer(1, 0.1 * inch))
-            story.append(Paragraph("RIESGOS IDENTIFICADOS", heading_style))
-            for riesgo in rec_principal.riesgos:
-                story.append(Paragraph(f"• {riesgo}", normal_style))
+        story.append(Spacer(1, 0.25 * inch))
+        story.append(Paragraph("RIESGOS IDENTIFICADOS", block_heading_style))
+        riesgos = rec_principal.riesgos or []
+        if riesgos:
+            for riesgo in riesgos:
+                story.append(Paragraph(riesgo, body_style))
+        else:
+            story.append(Paragraph("Sin riesgos identificados.", body_style))
 
-        story.append(Spacer(1, 0.2 * inch))
-
-        # Alternativas
+        story.append(Spacer(1, 0.25 * inch))
+        story.append(Paragraph("ALTERNATIVAS CONSIDERADAS", block_heading_style))
         if recommendation.alternativas:
-            story.append(Paragraph("ALTERNATIVAS CONSIDERADAS", heading_style))
-            for i, alt in enumerate(recommendation.alternativas, 1):
-                alt_text = f"""
-                <b>Alternativa {i}:</b><br/>
-                Fecha: {self._format_date(alt.get('fecha', '—'))}<br/>
-                Ventana: {self._format_date(alt.get('ventana', ['—', '—'])[0])} a {self._format_date(alt.get('ventana', ['—', '—'])[1])}<br/>
-                Confianza: {alt.get('confianza', 0) * 100:.1f}%<br/>
-                """
-                story.append(Paragraph(alt_text, normal_style))
-
-                if alt.get("pros"):
-                    story.append(Paragraph("<b>Ventajas:</b>", normal_style))
-                    for pro in alt.get("pros", []):
-                        story.append(Paragraph(f"✓ {pro}", normal_style))
-
-                if alt.get("contras"):
-                    story.append(Paragraph("<b>Desventajas:</b>", normal_style))
-                    for contra in alt.get("contras", []):
-                        story.append(Paragraph(f"✗ {contra}", normal_style))
-
+            for alt in recommendation.alternativas:
+                alt_fecha = self._format_date(alt.get("fecha"))
+                alt_window = self._format_window(alt.get("ventana", []))
+                try:
+                    alt_conf = float(alt.get("confianza", 0)) * 100
+                except (TypeError, ValueError):
+                    alt_conf = 0.0
+                story.append(Paragraph(f"Fecha: {alt_fecha}", body_style))
+                story.append(
+                    Paragraph(
+                        f"Ventana recomendada: {alt_window}",
+                        body_style,
+                    )
+                )
+                story.append(
+                    Paragraph(
+                        f"Confianza del modelo: {alt_conf:.1f}%",
+                        body_style,
+                    )
+                )
                 story.append(Spacer(1, 0.1 * inch))
+        else:
+            story.append(
+                Paragraph(
+                    "No se identificaron alternativas para esta recomendación.",
+                    body_style,
+                )
+            )
 
         story.append(Spacer(1, 0.3 * inch))
 
@@ -256,34 +246,37 @@ class PDFGeneratorService:
 
         return story
 
-    def _build_input_table(self, datos_entrada: Dict[str, Any]) -> List[List[str]]:
-        """Construye tabla con los datos ingresados por el usuario.
+    def _format_window(self, ventana: Any) -> str:
+        """Devuelve un texto amigable para una ventana recomendada."""
+        if (
+            not ventana
+            or not isinstance(ventana, (list, tuple))
+            or len(ventana) < 2
+        ):
+            return "—"
 
-        Args:
-            datos_entrada: Diccionario de datos de entrada
+        inicio = self._format_date(ventana[0])
+        fin = self._format_date(ventana[1])
 
-        Returns:
-            Lista de listas para la tabla
-        """
-        table_data = [["Campo", "Valor"]]
+        if inicio == "—" and fin == "—":
+            return "—"
+        if inicio == fin:
+            return inicio
+        return f"{inicio} – {fin}"
 
-        # Mapear campos importantes
-        field_labels = {
-            "lote_id": "ID del Lote",
-            "cultivo": "Cultivo",
-            "campana": "Campaña",
-            "fecha_consulta": "Fecha de Consulta",
-            "cliente_id": "ID del Cliente",
-        }
+    def _format_datetime_for_pdf(self, value: Any) -> str:
+        """Formatea un datetime con el estilo solicitado."""
+        if isinstance(value, datetime):
+            return value.strftime("%d/%m/%Y – %H:%M")
 
-        for key, label in field_labels.items():
-            value = datos_entrada.get(key)
-            if value:
-                if isinstance(value, datetime):
-                    value = self._format_datetime(value)
-                table_data.append([label, str(value)])
+        if isinstance(value, str):
+            try:
+                parsed = datetime.fromisoformat(value)
+                return parsed.strftime("%d/%m/%Y – %H:%M")
+            except ValueError:
+                return value
 
-        return table_data
+        return "—"
 
     @staticmethod
     def _format_date(date_value: Any) -> str:

--- a/backend/api/requirements.txt
+++ b/backend/api/requirements.txt
@@ -14,3 +14,5 @@ scikit-learn==1.4.2
 joblib==1.4.2
 scipy==1.12.0
 pytest==8.3.3
+reportlab==4.0.9
+python-dateutil==2.8.2

--- a/frontend/src/app/core/services/pdf-download.service.ts
+++ b/frontend/src/app/core/services/pdf-download.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+/**
+ * Servicio para manejar descargas de PDF de recomendaciones
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PdfDownloadService {
+  private readonly apiUrl = 'http://localhost:8000/api/v1';
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Descarga el PDF de una recomendación específica
+   * @param prediccionId ID de la predicción/recomendación
+   * @param cultivo Cultivo (opcional, para el nombre del archivo)
+   * @returns Observable que emite el Blob del PDF
+   */
+  downloadRecommendationPdf(
+    prediccionId: string,
+    cultivo?: string
+  ): Observable<Blob> {
+    const url = `${this.apiUrl}/recomendaciones/siembra/${prediccionId}/pdf`;
+    
+    return this.http.post(
+      url,
+      {},
+      {
+        responseType: 'blob'
+      }
+    );
+  }
+
+  /**
+   * Dispara la descarga del archivo PDF en el navegador
+   * @param blob Blob del PDF
+   * @param filename Nombre del archivo
+   */
+  triggerDownload(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/frontend/src/app/features/dashboard/dashboard.component.html
@@ -99,24 +99,28 @@
                 </ng-container>
               </td>
               <td>{{ formatRecommendationDate(item.recomendacion_principal.fecha_optima) }}</td>
-              <td class="window-cell">
-                <ng-container *ngIf="item.recomendacion_principal.ventana.length === 2; else dash">
-                  <span>{{ formatRecommendationDate(item.recomendacion_principal.ventana[0]) }}</span>
-                  <span class="range-separator">→</span>
-                  <span>{{ formatRecommendationDate(item.recomendacion_principal.ventana[1]) }}</span>
-                </ng-container>
+              <td>
+                <div class="window-cell">
+                  <ng-container *ngIf="item.recomendacion_principal.ventana.length === 2; else dash">
+                    <span>{{ formatRecommendationDate(item.recomendacion_principal.ventana[0]) }}</span>
+                    <span class="range-separator">→</span>
+                    <span>{{ formatRecommendationDate(item.recomendacion_principal.ventana[1]) }}</span>
+                  </ng-container>
+                </div>
               </td>
-              <td class="actions-cell">
-                <button 
-                  type="button" 
-                  class="btn btn-icon" 
-                  (click)="downloadRecommendationPdf(item)"
-                  [disabled]="isDownloadingPdf(item.id)"
-                  title="Descargar PDF de esta recomendación"
-                >
-                  <span *ngIf="!isDownloadingPdf(item.id)">📥</span>
-                  <span *ngIf="isDownloadingPdf(item.id)" class="loading"></span>
-                </button>
+              <td>
+                <div class="actions-cell">
+                  <button 
+                    type="button" 
+                    class="btn btn-icon" 
+                    (click)="downloadRecommendationPdf(item)"
+                    [disabled]="isDownloadingPdf(item.id)"
+                    title="Descargar PDF de esta recomendación"
+                  >
+                    <span *ngIf="!isDownloadingPdf(item.id)">📥</span>
+                    <span *ngIf="isDownloadingPdf(item.id)" class="loading"></span>
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>

--- a/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/frontend/src/app/features/dashboard/dashboard.component.html
@@ -84,6 +84,7 @@
               <th>Confianza</th>
               <th>Fecha óptima</th>
               <th>Ventana recomendada</th>
+              <th>Acciones</th>
             </tr>
           </thead>
           <tbody>
@@ -104,6 +105,18 @@
                   <span class="range-separator">→</span>
                   <span>{{ formatRecommendationDate(item.recomendacion_principal.ventana[1]) }}</span>
                 </ng-container>
+              </td>
+              <td class="actions-cell">
+                <button 
+                  type="button" 
+                  class="btn btn-icon" 
+                  (click)="downloadRecommendationPdf(item)"
+                  [disabled]="isDownloadingPdf(item.id)"
+                  title="Descargar PDF de esta recomendación"
+                >
+                  <span *ngIf="!isDownloadingPdf(item.id)">📥</span>
+                  <span *ngIf="isDownloadingPdf(item.id)" class="loading"></span>
+                </button>
               </td>
             </tr>
           </tbody>

--- a/frontend/src/app/features/dashboard/dashboard.component.scss
+++ b/frontend/src/app/features/dashboard/dashboard.component.scss
@@ -248,6 +248,50 @@
   white-space: nowrap;
 }
 
+.actions-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  font-size: 1.2rem;
+  border-radius: 8px;
+  border: 1px solid rgba(25, 118, 210, 0.3);
+  background: rgba(25, 118, 210, 0.08);
+  color: var(--primary-color);
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(25, 118, 210, 0.15);
+    border-color: rgba(25, 118, 210, 0.6);
+    transform: translateY(-2px);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .loading {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid rgba(25, 118, 210, 0.3);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+}
+
 .range-separator {
   color: var(--text-secondary);
 }

--- a/frontend/src/app/features/dashboard/dashboard.component.scss
+++ b/frontend/src/app/features/dashboard/dashboard.component.scss
@@ -239,20 +239,28 @@
       white-space: nowrap;
     }
   }
+
+  th:last-child,
+  td:last-child {
+    width: 110px;
+    text-align: center;
+  }
 }
 
 .window-cell {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.5rem;
+  width: 100%;
   white-space: nowrap;
 }
 
 .actions-cell {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  white-space: nowrap;
+  width: 100%;
 }
 
 .btn-icon {

--- a/frontend/src/app/features/recomendaciones/recomendaciones.component.html
+++ b/frontend/src/app/features/recomendaciones/recomendaciones.component.html
@@ -162,7 +162,24 @@
         </div>
 
         <footer class="result-footer">
-          <span>Generado el {{ formatDateTime(result.fecha_generacion) }}</span>
+          <div class="footer-content">
+            <span>Generado el {{ formatDateTime(result.fecha_generacion) }}</span>
+          </div>
+          <button 
+            type="button" 
+            class="btn btn-secondary" 
+            (click)="downloadPdf()" 
+            [disabled]="isDownloadingPdf"
+            *ngIf="result"
+          >
+            <span *ngIf="!isDownloadingPdf">
+              📥 Descargar PDF
+            </span>
+            <span *ngIf="isDownloadingPdf">
+              <span class="loading"></span>
+              Descargando...
+            </span>
+          </button>
         </footer>
       </ng-container>
     </section>

--- a/frontend/src/app/features/recomendaciones/recomendaciones.component.scss
+++ b/frontend/src/app/features/recomendaciones/recomendaciones.component.scss
@@ -492,10 +492,24 @@
 }
 
 .result-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
   margin-top: 2rem;
-  text-align: right;
-  color: var(--text-secondary);
-  font-size: 0.85rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+
+  .footer-content {
+    flex: 1;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+
+  .btn {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
 }
 
 .alert-error {

--- a/frontend/src/app/shared/models/recommendations.model.ts
+++ b/frontend/src/app/shared/models/recommendations.model.ts
@@ -39,6 +39,7 @@ export interface RecomendacionResponse<TPrincipal = unknown, TAlternative = unkn
   fecha_generacion: string;
   metadata?: Record<string, unknown>;
   datos_entrada?: Record<string, unknown>;
+  prediccion_id?: string;
 }
 
 export interface SiembraRecommendationResponse extends RecomendacionResponse<RecommendationWindow, RecommendationAlternative> {


### PR DESCRIPTION
Se agrego boton para generar pdf mostrando el resumen de la recomendacion. 
Nuevo campo prediccion_id en SiembraRecommendationResponse para que el front reciba el ID generado al guardar la predicción y pueda pedir el PDF de ese registro concreto usando /siembra/{prediccion_id}/pdf.
lo hice porque antes ese ID no se devolvía y el front no podía decirle al backend qué recomendación concreta quería convertir en PDF; ahora la respuesta devuelve el identificador recién persistido y el frontend usa /siembra/{prediccion_id}/pdf para descargar el mismo registro.
Este cambio no afecta la lógica existente del backend. El campo prediccion_id es opcional y solo se completa cuando la recomendación fue guardada correctamente. No modifica los flujos actuales ni agrega dependencias nuevas; simplemente expone el identificador que ya se generaba internamente para que el frontend pueda solicitar el PDF del registro recién creado._